### PR TITLE
Skipped Style and Script Tags

### DIFF
--- a/application/hooks/Minifyhtml.php
+++ b/application/hooks/Minifyhtml.php
@@ -28,12 +28,14 @@ class Minifyhtml {
                 (?:         # Zero or more of...
                   [^<]++    # Either one or more non-"<"
                 | <         # or a < starting a non-blacklist tag.
-                  (?!/?(?:textarea|pre)\b)
+                            # Skip Script and Style Tags
+                  (?!/?(?:textarea|pre|script|style)\b)
                 )*+         # (This could be "unroll-the-loop"ified.)
               )             # End (unnecessary) group.
               (?:           # Begin alternation group.
                 <           # Either a blacklist start tag.
-                (?>textarea|pre)\b
+                            # Dont foget the closing tags 
+                (?>textarea|pre|script|style)\b
               | \z          # or end of file.
               )             # End alternation group.
             )  # If we made it here, we are not in a blacklist tag.


### PR DESCRIPTION
Unless you do not use _single line_ comments `// `
Or you do not have Inline script tags 
Other than that it breaks the code .
 
[Check out the DEMO](https://www.youtube.com/watch?v=vQsZtz0lkEg)

Cheers ,
Go Play **[Sticky Bubble](https://play.google.com/store/apps/details?id=com.fadsel.stickybubble)** on **Google Play**